### PR TITLE
IssueID #2 - Configure whether to run proxy API:

### DIFF
--- a/src/gulp/tasks/serve-dist.js
+++ b/src/gulp/tasks/serve-dist.js
@@ -67,7 +67,7 @@ class ServeDistTaskLoader extends AbstractTaskLoader {
         gulp.task("serve-dist", "Build and serve the production version (i.e., 'dist' folder contents", () =>{
             let tasks = [ "default" ];
 
-            if(gulp.options.proxy){
+            if(gulp.options.proxy.start){
                 tasks.unshift("proxy");
             }
 

--- a/src/gulp/tasks/serve.js
+++ b/src/gulp/tasks/serve.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import gutil from "gulp-util";
 import AbstractTaskLoader from "../abstractTaskLoader";
 import config from "../config";
 import utils from "../utils";
@@ -141,7 +142,9 @@ class ServeTaskLoader extends AbstractTaskLoader {
         gulp.task("prepare-serve", "Do all the necessary preparatory work for the serve task", () =>{
             // Only run the proxy task if there is configuration for it, the proxy task is mandatory if
             // the proxy configuration is present.
-            if(gulp.options.proxy){
+            gutil.log(gutil.colors.green("'Run Proxy Task: " + gulp.options.proxy.start));
+
+            if(gulp.options.proxy.start){
                 return runSequence([
                     "clean",
                     "ts-lint",


### PR DESCRIPTION
So far we have only wanted to run the proxy API server, for front-end
development purposes. Now we want to integrate the front-end/back-end
code. We need to be able to pass proxied requests to the real back-end
not just to the proxy API server.

Now, if you configure start to be false, the system will just forward
requests to the proxy you define. If start = true, then it will also
run the proxy task, which should setup the proxy API server.y
