### PR TITLE
Upgrade tslint to support extends

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,5 @@
+* 0.7.6
+  * Upgrade gulp-tslint to version which supports 'extends' in the tslint.json file.
 * 0.7 5
   * Add capability to proxy to another server, not just the Dev API.
 * 0.7 4

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gulp-size": "2.1.x",
     "gulp-sourcemaps": "1.6.x",
     "gulp-strip-debug": "1.1.x",
-    "gulp-tslint": "4.3.x",
+    "gulp-tslint": "^5.0.0",
     "gulp-typescript": "2.12.x",
     "gulp-uglify": "1.5.x",
     "gulp-uncss": "1.0.x",
@@ -107,7 +107,7 @@
     "require-dir": "0.3.x",
     "run-sequence": "1.1.x",
     "systemjs-builder": "0.15.x",
-    "tslint": "3.7.x",
+    "tslint": "^3.10.2",
     "typescript": "1.8.x"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-build",
   "description": "Build Angular 2/JSPM with Gulp. Forked from ModernWebDevBuild.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "Mark Small",
     "email": "m.small@ed.ac.uk"


### PR DESCRIPTION
Updates the version of gulp-tslint to support 'extends' in the tslint.json file.
