### PR TITLE
Add support for pre-compiling angular templates when doing a dist build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sass"
   ],
   "devDependencies": {
+    "gulp-filter": "^4.0.0",
     "jasmine": "2.4.x",
     "karma-jasmine": "0.3.x"
   },

--- a/src/gulp/config.js
+++ b/src/gulp/config.js
@@ -6,6 +6,7 @@ import path from "path";
 let extensions = {
     javascript: ".js",
     typescript: ".ts",
+    ngfactories: ".ngfactory.ts",
     css: ".css",
     sass: ".scss",
     html: ".html",
@@ -34,7 +35,8 @@ let globs = {
     any: "/**/*",
     scripts: {
         javascript: "/**/*" + extensions.javascript,
-        typescript: "/**/*" + extensions.typescript
+        typescript: "/**/*" + extensions.typescript,
+        ngFactories: "/**/*" + extensions.ngfactories
     },
     styles: {
         css: "/**/*" + extensions.css,

--- a/src/gulp/tasks/clean.js
+++ b/src/gulp/tasks/clean.js
@@ -10,10 +10,13 @@ class CleanTaskLoader extends AbstractTaskLoader {
     registerTask(gulp){
         super.registerTask(gulp);
 
+        let srcFolder = gulp.options.folders ? gulp.options.folders.app : config.folders.app;
+
         gulp.task("clean", "Clean output directories", () =>{
             del([
                     config.folders.temp,
-                    config.folders.dist + config.globs.any
+                    config.folders.dist + config.globs.any,
+                    srcFolder + config.globs.scripts.ngFactories
                 ], {
                     dot: true
                 }

--- a/src/gulp/tasks/default.js
+++ b/src/gulp/tasks/default.js
@@ -16,7 +16,8 @@ class DefaultTaskLoader extends AbstractTaskLoader {
                     "clean",
                     "ts-lint",
                     "check-js-style",
-                    "check-js-quality"
+                    "check-js-quality",
+                    "scripts-ngc"
                 ], [
                     "scripts-typescript",
                     "scripts-javascript"

--- a/src/gulp/tasks/default.js
+++ b/src/gulp/tasks/default.js
@@ -16,7 +16,8 @@ class DefaultTaskLoader extends AbstractTaskLoader {
                     "clean",
                     "ts-lint",
                     "check-js-style",
-                    "check-js-quality",
+                    "check-js-quality"
+                ], [
                     "scripts-ngc"
                 ], [
                     "scripts-typescript",

--- a/src/gulp/tasks/scripts-ngc.js
+++ b/src/gulp/tasks/scripts-ngc.js
@@ -7,9 +7,10 @@ class ScriptsTypeScriptTaskLoader extends AbstractTaskLoader {
     registerTask(gulp){
         super.registerTask(gulp);
 
-        gulp.task("scripts-ngc", "Run the Angular 2 NGC compiler", () =>{
+        gulp.task("scripts-ngc", "Run the Angular 2 NGC compiler", (callback) =>{
             exec("./node_modules/.bin/ngc -p tsconfig-aot.json", (err, stdout, stderr) =>{
                 console.log(stderr);
+                callback();
             });
         });
     }

--- a/src/gulp/tasks/scripts-ngc.js
+++ b/src/gulp/tasks/scripts-ngc.js
@@ -1,0 +1,19 @@
+"use strict";
+
+import AbstractTaskLoader from "../abstractTaskLoader";
+let exec = require("child_process").exec;
+
+class ScriptsTypeScriptTaskLoader extends AbstractTaskLoader {
+    registerTask(gulp){
+        super.registerTask(gulp);
+
+        gulp.task("scripts-ngc", "Run the Angular 2 NGC compiler", () =>{
+            exec("./node_modules/.bin/ngc -p tsconfig-aot.json", (err, stdout, stderr) =>{
+                console.log(stderr);
+            });
+        });
+    }
+}
+
+module.exports = new ScriptsTypeScriptTaskLoader();
+

--- a/src/gulp/tasks/ts-lint.js
+++ b/src/gulp/tasks/ts-lint.js
@@ -7,6 +7,7 @@ import config from "../config";
 import tslint from "gulp-tslint";
 import iff from "gulp-if";
 import size from "gulp-size";
+import filter from "gulp-filter";
 //import debug from "gulp-debug";
 
 let browserSync = require("browser-sync").get(config.webServerNames.dev);
@@ -17,6 +18,7 @@ class TsLintTaskLoader extends AbstractTaskLoader {
 
         gulp.task("ts-lint", "Lint TypeScript code", () =>{
             let src = null;
+            const noNgFactory = filter([ "**/*.ts", "!**/*.ngfactory.ts" ]);
 
             if(gulp.options.folders){
                 src = [ gulp.options.folders.app + config.globs.scripts.typescript ];
@@ -27,6 +29,9 @@ class TsLintTaskLoader extends AbstractTaskLoader {
             return gulp.plumbedSrc(// handle errors nicely (i.e., without breaking watch)
                 src // only the application's code needs to be checked
                 )
+
+                // Don't tslint generated code
+                .pipe(noNgFactory)
 
                 // Display the files in the stream
                 //.pipe(debug({title: "Stream contents:", minimal: true}))

--- a/src/gulp/tasks/ts-lint.js
+++ b/src/gulp/tasks/ts-lint.js
@@ -18,7 +18,7 @@ class TsLintTaskLoader extends AbstractTaskLoader {
 
         gulp.task("ts-lint", "Lint TypeScript code", () =>{
             let src = null;
-            const noNgFactory = filter([ "**/*.ts", "!**/*.ngfactory.ts" ]);
+            const noNgFactory = filter([ config.globs.scripts.typescript, "!" + config.globs.scripts.ngFactories ]);
 
             if(gulp.options.folders){
                 src = [ gulp.options.folders.app + config.globs.scripts.typescript ];


### PR DESCRIPTION
Adds a new task to use the Angular NGC compiler when running serve-dist or compile tasks. This pre-compiles the angular templates so they load much faster.

Also makes sure to exclude the ngfactories from tslint.
